### PR TITLE
osis2html5の更新に伴ってsitemapも更新

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,274 +2,274 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 <url>
   <loc>https://jpn.bible/</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/gen</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/exod</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/lev</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/num</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/deut</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/josh</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/judg</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/ruth</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/1sam</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/2sam</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/1kgs</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/2kgs</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/1chr</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/2chr</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/ezra</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/neh</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/esth</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/job</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/ps</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/prov</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/eccl</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/song</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/isa</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/jer</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/lam</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/ezek</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/dan</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/hos</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/joel</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/amos</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/obad</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/jonah</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/mic</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/nah</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/hab</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/zeph</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/hag</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/zech</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/mal</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/matt</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/mark</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/luke</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/john</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/acts</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/rom</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/1cor</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/2cor</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/gal</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/eph</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/phil</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/col</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/1thess</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/2thess</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/1tim</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/2tim</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/titus</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/phlm</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/heb</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/jas</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/1pet</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/2pet</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/1john</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/2john</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/3john</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/jude</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 <url>
   <loc>https://jpn.bible/kougo/rev</loc>
-  <lastmod>2018-11-20T23:25:40+00:00</lastmod>
+  <lastmod>2019-03-27T12:00:00+09:00</lastmod>
 </url>
 </urlset>


### PR DESCRIPTION
現行だとsitemapを手動更新しなければ行けなくて辛い……

ともあれ、更新します。 `<rp>` タグの追加によるページ更新が起きたので、再クロールを各botに指示するためです。