### PR TITLE
Google Fonts APIで公式にサポートされた `font-display` 指定機能を利用

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,7 @@ HEAD = <<EOS.chomp
 </script>
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
-<link href="https://google-fonts-font-display-swap.netlify.com/google-fonts.css" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css?family=Noto+Serif+JP&display=swap" rel="stylesheet"/>
 <link rel="canonical" href="%<url>s"/>
 <meta property="og:url" content="%<url>s"/>
 <link rel="stylesheet" href="/css/global.css"/>

--- a/template/index.html.erb
+++ b/template/index.html.erb
@@ -13,7 +13,7 @@
 </script>
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
-<link href="https://google-fonts-font-display-swap.netlify.com/google-fonts.css" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css?family=Noto+Serif+JP&display=swap" rel="stylesheet"/>
 <link rel="canonical" href="https://jpn.bible"/>
 <meta property="og:url" content="https://jpn.bible"/>
 <link rel="stylesheet" href="/css/index.css"/>


### PR DESCRIPTION
https://github.com/google/fonts/issues/358#issuecomment-490730397 のとおり、8日ほど前のGoogle I/Oで、Google Fonts APIによって公式に `font-display` を指定する機能が実装されたとアナウンスされたようです。
https://developers.google.com/fonts/docs/getting_started#use_font-display

今までは、Google提供のCSSファイル内に `font-display: swap` を挟むためだけに独自機構を使っていましたが、それをする必要が無くなったので、CSSとして直接上記APIを参照する形式に修正します。